### PR TITLE
Add conditional cgo linking directives for mac and linux

### DIFF
--- a/sox.go
+++ b/sox.go
@@ -11,7 +11,8 @@ import (
 )
 
 /*
-#cgo pkg-config: sox
+#cgo linux pkg-config: sox
+#cgo darwin LDFLAGS: -L/usr/local/lib -lsox
 #include <sox.h>
 #include <stdlib.h>
 extern int go_flow_shim_impl(void* fn, sox_bool all_done);


### PR DESCRIPTION
Currently, when compiling sox-go in OSX, it fails because `pkg-config` is not found on that platform.
With this change, conditional linking directives are added that are platform specific. For OSX, a `brew install sox` is needed for the directives provided to work and link correctly.